### PR TITLE
Fixed typographical error, changed auxilary to auxiliary in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ GenerateGaussianSequence.m
 --------------------------
 
 Description: Generates n sequence of normally distributed pseudo random numbers of the numbers 
-{0, 1}. This is an auxilary script which is called inside embbedding and extracting programs.
+{0, 1}. This is an auxiliary script which is called inside embbedding and extracting programs.
 
 Arguments: `n`
 


### PR DESCRIPTION
israkir, I've corrected a typographical error in the documentation of the [cox-watermarking](https://github.com/israkir/cox-watermarking) project. You should be able to merge this pull request automatically. However, if this was intentional or you enjoy living in linguistic squalor please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
